### PR TITLE
PATCH: Prevents calling strpos with empty needle

### DIFF
--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -2614,8 +2614,10 @@ class i18n extends SS_Object implements TemplateGlobalProvider, Flushable {
 				$themesBase = Director::baseFolder() . '/themes';
 				if(is_dir($themesBase)) {
 					foreach(scandir($themesBase) as $theme) {
+						$themename = (string)Config::inst()->get('SSViewer', 'theme');
 						if(
-							strpos($theme, (string)Config::inst()->get('SSViewer', 'theme')) === 0
+							!empty($themename)
+							&& strpos($theme, $themename) === 0
 							&& file_exists("{$themesBase}/{$theme}/lang/")
 						) {
 							$filename = $adapter->getFilenameForLocale($locale);


### PR DESCRIPTION
We happen to run into this warning:
```
[Warning] strpos(): Empty needle
Line 2618 in ./framework/i18n/i18n.php

2618	strpos($theme, (string)Config::inst()->get('SSViewer', 'theme')) === 0
```
I suggest to test the needle against emptyness before invoking strpos.
